### PR TITLE
Small docker-compose fixes

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,4 +22,4 @@ services:
       - 9000:8080
     environment:
       IS_LOCAL: true
-      DYNAMODB_ENDPOINT: dynamodb
+      DYNAMODB_HOST: dynamodb

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,5 +21,5 @@ services:
     ports:
       - 9000:8080
     environment:
-      IS_LOCAL: true
+      IS_LOCAL: 'true'
       DYNAMODB_HOST: dynamodb


### PR DESCRIPTION
Two small issue fixes around the docker-compose file

## Issue: 
First issue was a bit strange as it didn't cause an issue on my first few `docker-compose up` commands, so not sure why it only appeared after a little bit. Pretty much we cant have a boolean value for an environment variable
```
➜  docker-compose up -d
ERROR: The Compose file './docker-compose.yaml' is invalid because:
services.lambda.environment.IS_LOCAL contains true, which is an invalid type, it should be a string, number, or a null
```

Solution Change environment variable `IS_LOCAL` from `true` to `'true'` as boolean is not an allowed value, but a string is.


## Issue 2: 
By default the lambda can't find the DynamoDB host, and it will use `localhost` regardless of the `DYNAMODB_ENDPOINT` value you set.

```
START RequestId: 60b9fb19-2d8b-47a3-a609-e97586b898bc Version: $LATEST
} '$metadata': { attempts: 1, totalRetryDelay: 0 } (node:net:1187:16) { ERROR   Error: connect ECONNREFUSED 127.0.0.1:8000
END RequestId: 60b9fb19-2d8b-47a3-a609-e97586b898bc
```

This is caused as the value being looked up in [aws.ts ](https://github.com/cultureamp/sre-tech-interview/blob/76c9cf7c23950840b3bdebff727700bfb590cc38/src/aws.ts#L3) is `DYNAMODB_HOST`.

So the simple fix is to rename our docker-compose environment variable from `DYNAMODB_ENDPOINT` to `DYNAMODB_HOST`
