### PR TITLE
fix: compose startup issue, improve README structure

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,15 +1,20 @@
-version: "3"
 services:
   dynamodb:
     image: amazon/dynamodb-local
     command: -jar DynamoDBLocal.jar -sharedDb
     ports:
       - 8000:8000
+    healthcheck:
+      test: ["CMD-SHELL", "db_status=\"$(curl -s http://localhost:8000 -w ''%{http_code}'' -o /dev/null)\"; [ \"$db_status\" == \"400\" ] && exit 1 || exit 0"]
+      interval: 1s
+      timeout: 10s
+      retries: 10
 
   dynamodb-create-table:
     image: amazon/aws-cli
     depends_on:
-      - dynamodb
+      dynamodb:
+        condition: service_healthy
     entrypoint: /bin/sh
     command: create-table.sh
     working_dir: /app
@@ -17,6 +22,9 @@ services:
       - ./dynamodb:/app
 
   lambda:
+    depends_on:
+      dynamodb:
+        condition: service_healthy
     build: .
     ports:
       - 9000:8080

--- a/dynamodb/create-table.sh
+++ b/dynamodb/create-table.sh
@@ -4,4 +4,10 @@ export AWS_REGION=local
 export AWS_ACCESS_KEY_ID=local
 export AWS_SECRET_ACCESS_KEY=local
 
-aws dynamodb --endpoint http://dynamodb:8000 create-table --cli-input-json file://create-table.json
+endpoint="http://dynamodb:8000"
+
+if aws dynamodb --endpoint "$endpoint" describe-table --table-name comment-vibe --query 'Table.TableStatus' > /dev/null 2>&1; then
+  echo "Table already exists, no action required. Remove and recreate the 'dynamodb' container to reset the database."
+else
+  aws dynamodb --endpoint "$endpoint" create-table --cli-input-json file://create-table.json
+fi

--- a/readme.md
+++ b/readme.md
@@ -4,11 +4,11 @@
 
 The Comment Vibe API is a small microservice for calculating sentiment using [AFINN-165](https://www.npmjs.com/package/sentiment) for comments left on surveys.
 
-It exposes an API using API Gateway V2 and AWS Lambda and persists survey comments in a DynamoDB table. The infrastructure is managed and deployed using the AWS CDK
+It exposes an API using API Gateway V2 and AWS Lambda and persists survey comments in a DynamoDB table. The infrastructure is managed and deployed using the AWS CDK.
 
 ![Comment Vibe API Architecture Diagram](./docs/comment-vibe.svg)
 
-```
+```text
 sre-tech-interview
 ├── ops                  AWS CDK project for deploying Comment Vibe
 ├── src                  Node.js application source code for Comment Vibe
@@ -18,21 +18,84 @@ sre-tech-interview
 └── readme.md            This document
 ```
 
+## Getting started
+
+Requirements:
+
+- Docker (or compatible), with Docker Compose v2 and above
+- (optional) `asdf` or `mise` for easy tool installation -- this will install Node and Yarn using the `.tool-versions` file.
+- Node 20
+- Yarn 1.22.19
+
+> [!TIP]
+> Consider a GitHub Codespace (or similar) that has this tooling installed if
+> it's not readily available on the machine you're using for the interview.
+
+### Running in Docker
+
+Comment Vibe can be run locally using Docker to imitate the AWS Lambda and DynamoDB infrastructure.
+
+Build images:
+
+```console
+$ docker compose build
+```
+
+Run local containers:
+
+```console
+$ docker compose up
+```
+
+When the service starts, a container will run a command to create the necessary
+table. The status of this will be shown in the logs.
+
+Follow on to the next section for details on running the API locally for development. Note that it is possible to communicate with the API [in the container too](#sending-requests-to-the-api-in-docker-compose), using a different payload.
+
+### Running the API locally
+
+> [!TIP]
+> Running directly on the local host allows for an easier dev/test workflow than
+> when all services are running in Docker. The local API instance relies on the
+> local DynamoDB instance running in `docker compose`.
+
+Install dependencies
+
+```console
+$ yarn install
+```
+
+Run Express.js app locally
+
+```console
+$ yarn start
+yarn run v1.22.15
+dotenv ts-node src/local.ts
+Server started on port 3000
+```
+
+> [!TIP]
+>
+> - Restart the `yarn` process to apply local changes.
+> - Use the examples from the next section against your local copy of the API
+> when testing.
+
 ## The API
 
 Comment Vibe exposes two endpoints for use. See the [OpenAPI](./openapi.yaml) specification for more complete details.
 
-### Comment on a survey : `POST /comment/:surveyId`
+### Comment on a survey: `POST /comment/:surveyId`
 
 - Receives `surveyId` as parameter in path
 - Receives new comment as JSON in the request body of a `POST` request
 - Calculates `sentiment` field for the comment and saves it into the DynamoDB table
 - Returns the comment with `sentiment` field set
 
-```sh
+```console
 # example request and response
 
-curl -X POST -H 'Content-Type: application/json' ${HOST}/comment/my-survey -d '{"content":"Today is a good day."}'
+$ HOST=http://localhost:3000
+$ curl -X POST -H 'Content-Type: application/json' ${HOST}/comment/my-survey -d '{"content":"Today is a good day."}'
 
 {
   "action": "add",
@@ -51,10 +114,11 @@ curl -X POST -H 'Content-Type: application/json' ${HOST}/comment/my-survey -d '{
 - Queries DynamoDB for all comments for the given `surveyId`
 - Buckets them based on `sentiment` and returns a basic report of the survey comments
 
-```sh
+```console
 # example request and response
 
-curl -X GET -H 'Content-Type: application/json' ${HOST}/report/my-survey
+$ HOST=http://localhost:3000
+$ curl -X GET -H 'Content-Type: application/json' ${HOST}/report/my-survey
 
 {
   "action": "report",
@@ -68,30 +132,7 @@ curl -X GET -H 'Content-Type: application/json' ${HOST}/report/my-survey
 }
 ```
 
-## Setting up locally
-
-Comment Vibe can be run locally using Docker to imitate the AWS Lambda and DynamoDB infrastructure.
-
-Requirements to run in Docker
-- Docker
-
-Build images with
-
-```
-❯ docker compose build
-```
-
-Run local containers with
-
-```
-❯ docker compose up
-```
-
-### Creating the DynamoDB table in DynamoDB Local
-
-A container within the Docker Compose will create the required table within DynamoDB Local automatically. Check the logs for the `create-table` container if you have issues with the table.
-
-### Sending requests to local Lambda container
+### Sending requests to the API in Docker Compose
 
 The Lambda container expects to receive an AWS API Gateway v2 payload. See below for an example minimal request JSON for wrapping up a Comment Vibe request. See this [reference](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html) for a complete example.
 
@@ -127,40 +168,6 @@ curl -X POST http://localhost:9000/2015-03-31/functions/function/invocations -d 
   }
 }'
 ```
-
-
-## Running Express.js application locally
-
-The Express.js application for Comment Vibe can also be run locally without Docker which provides a faster iteration loop for development.
-
-Requirements to run application locally:
-- Node 16
-- `yarn`
-
-These can be installed using [asdf](https://asdf-vm.com/guide/getting-started.html), which will utilize the versions set in `.tool-versions`.
-
-Install dependencies
-
-```
-❯ yarn install
-```
-
-Run Express.js app locally
-
-```sh
-❯ yarn start
-yarn run v1.22.15
-$ dotenv ts-node src/local.ts
-Server started on port 3000
-```
-
-### Connecting to DynamoDB from local Express.js
-
-Express.js app running locally will expect to connect to the DynamoDB Local instance running in Docker Compose.
-
-### Sending requests to local Express.js
-
-The Express.js app expects to receive the Comment Vibe request JSON directly. See the API documentation earlier in this document.
 
 ## Deploying to AWS with the CDK application
 


### PR DESCRIPTION
We've noticed in interviews that some candidate have a launch failure with the schema container. Instead of expecting a nervous candidate to tap-dance, we're fixing that bug.

Also changed is the documentation flow, so it reads through getting it up and running before there's detail about hitting the API. Also, running locally is prioritised over running the API in a container.